### PR TITLE
Don't show admin menu for non-admin users

### DIFF
--- a/src/class-SH-Crafty-Social-Buttons-Plugin.php
+++ b/src/class-SH-Crafty-Social-Buttons-Plugin.php
@@ -217,7 +217,7 @@ class SH_Crafty_Social_Buttons_Plugin
       $this->plugin_screen_hook_suffix = add_options_page(
          __('Crafty Social Buttons', $this->plugin_slug),
          __('Crafty Social Buttons', $this->plugin_slug),
-         'read',
+         'manage_options',
          $this->plugin_slug,
          array($this->admin_class, 'display_plugin_admin_page')
       );


### PR DESCRIPTION
Changed capability to avoid the display of the plugin's admin page link for non-admin users. This is not actually a security issue, as the admin page performs a permission check, but it's still an admin UI pollution for non-admin users.
